### PR TITLE
Add improved Spain-France prediction example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Football Match Outcome Prediction
+
+This repository contains a small machine learning demo that predicts whether the
+home team will win a football match. It uses actual results from the 2022 FIFA
+World Cup and trains a logistic regression model on the ranking difference
+between the two teams.
+
+## Dataset
+
+A small dataset of real match results from the 2022 FIFA World Cup group stage
+is provided in `data/football_matches.csv`. It includes the following columns:
+
+- `home_team`
+- `away_team`
+- `home_team_rank`
+- `away_team_rank`
+- `home_goals`
+- `away_goals`
+- `home_win` (1 if the home team won, otherwise 0)
+
+Only the ranking difference is used as a feature for training in this demo.
+
+## Running the example
+
+1. Install dependencies (requires Python 3):
+   ```bash
+   pip install pandas scikit-learn
+   ```
+2. Run the script:
+```bash
+python3 main.py
+```
+   The script trains a logistic regression model, prints the accuracy on a test
+   split and then predicts the outcome of the Spain vs France match.
+
+This example is intentionally lightweight—it demonstrates the workflow of data
+loading, training and making predictions with scikit-learn. The dataset is tiny
+and the model is not tuned for production use.

--- a/data/football_matches.csv
+++ b/data/football_matches.csv
@@ -1,0 +1,11 @@
+home_team,away_team,home_team_rank,away_team_rank,home_goals,away_goals,home_win
+Qatar,Ecuador,50,44,0,2,0
+Senegal,Netherlands,18,8,0,2,0
+England,Iran,5,20,6,2,1
+Argentina,Saudi Arabia,3,51,1,2,0
+France,Australia,4,38,4,1,1
+Germany,Japan,11,26,1,2,0
+Spain,Costa Rica,7,31,7,0,1
+Belgium,Canada,2,41,1,0,1
+Brazil,Serbia,1,21,2,0,1
+Portugal,Ghana,9,61,3,2,1

--- a/main.py
+++ b/main.py
@@ -1,0 +1,64 @@
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import accuracy_score
+
+DATA_PATH = "data/football_matches.csv"
+
+
+def load_data(path: str = DATA_PATH):
+    """Load match results and return dataframe, features and labels."""
+    data = pd.read_csv(path)
+    data["rank_diff"] = data["home_team_rank"] - data["away_team_rank"]
+    X = data[["rank_diff"]]
+    y = data["home_win"]
+    return data, X, y
+
+
+def train_model(X: pd.DataFrame, y: pd.Series) -> LogisticRegression:
+    """Train logistic regression and print accuracy."""
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
+    model = LogisticRegression()
+    model.fit(X_train, y_train)
+    y_pred = model.predict(X_test)
+    accuracy = accuracy_score(y_test, y_pred)
+    print(f"Test accuracy: {accuracy:.2f}")
+    return model
+
+
+def get_team_rank(data: pd.DataFrame, team: str) -> int:
+    """Return the known ranking for a team from the dataset."""
+    ranks = pd.concat(
+        [
+            data.loc[data["home_team"] == team, "home_team_rank"],
+            data.loc[data["away_team"] == team, "away_team_rank"],
+        ]
+    )
+    return int(ranks.iloc[0]) if not ranks.empty else None
+
+
+def predict_match(model: LogisticRegression, data: pd.DataFrame, home_team: str, away_team: str) -> int:
+    """Predict the outcome of a match given the team names."""
+    home_rank = get_team_rank(data, home_team)
+    away_rank = get_team_rank(data, away_team)
+    if home_rank is None or away_rank is None:
+        raise ValueError("Team ranking not found in dataset")
+    rank_diff = home_rank - away_rank
+    proba = model.predict_proba([[rank_diff]])[0, 1]
+    pred = int(proba >= 0.5)
+    result = "home win" if pred else "home draw/loss"
+    print(
+        f"Prediction for {home_team} vs {away_team}: {result} (prob={proba:.2f})"
+    )
+    return pred
+
+def main():
+    data, X, y = load_data()
+    model = train_model(X, y)
+    # Predict the Spain vs France match with Spain at home
+    predict_match(model, data, "Spain", "France")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- enhance README instructions for running the demo
- refactor `main.py` with helper functions
- show how to predict Spain vs France using real 2022 World Cup rankings

## Testing
- `pip install pandas scikit-learn --quiet`
- `python3 main.py`


------
https://chatgpt.com/codex/tasks/task_e_683f84a212148328aac33d4ccac7c51f